### PR TITLE
Docs: Fix broken extension links in user-guide

### DIFF
--- a/docs/docs/user-guide/index.html
+++ b/docs/docs/user-guide/index.html
@@ -95,13 +95,13 @@ directory. For more information about the <code>.hintrc</code> file and options,
 <h3 id=use-webhint-with-microsoft-visual-studio-code>Use webhint with Microsoft Visual Studio Code<a href="#use-webhint-with-microsoft-visual-studio-code" class="headerlink" title="Use webhint with Microsoft Visual Studio Code"></a></h3><p>The <strong>webhint Visual Studio Code extension</strong> runs and reports <code>webhint</code>
 diagnostic data for your workspace files inside Visual Studio Code.</p>
 <p>For more information about the using <code>webhint</code> within Visual Studio Code, go to
-<a href="../../../extension-vscode/"  title="Webhint VS Code Extension | webhint">webhint Visual Studio Code extension</a>.</p>
+<a href="./extensions/vscode-webhint/"  title="Webhint VS Code Extension | webhint">webhint Visual Studio Code extension</a>.</p>
 <h3 id=use-webhint-with-your-browser>Use webhint with your browser<a href="#use-webhint-with-your-browser" class="headerlink" title="Use webhint with your browser"></a></h3><p>The <strong>webhint browser extension</strong> provides a visual interface that allows you to
 run and re-run site scans that test against multiple browsers and hint types
 directly in DevTools inside your browser.  It is available for Google Chrome,
 Microsoft Edge, Mozilla Firefox.</p>
 <p>For more information about the using <code>webhint</code> within your browser, go to
-<a href="../../../extension-browser/"  title="Webhint Browser Extension EditSignal Issue | webhint">webhint browser extension</a>.</p>
+<a href="./extensions/extension-browser/"  title="Webhint Browser Extension EditSignal Issue | webhint">webhint browser extension</a>.</p>
 <h2 id=next-steps>Next Steps<a href="#next-steps" class="headerlink" title="Next Steps"></a></h2><ul>
 <li><a href="./concepts/hints/"  title="Hints | webhint">Hints</a></li>
 <li><a href="./concepts/configurations/"  title="Configurations | webhint">Configurations</a></li>


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/webhint.io)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

## Short description of the change(s)

<!--

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->

The links to the VSCode and browser extension mentioned on this page are broken right now. I've fixed them:
https://webhint.io/docs/user-guide/#use-webhint-with-microsoft-visual-studio-code