### PR TITLE
Fix: changing safeLoad for load in js-yaml>4

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -58,9 +58,9 @@ const commonConfiguration = (app) => {
     const menuDataDir = path.join(hexoDir, 'content/_data/menu.yml');
     const configDataDir = path.join(rootPath, '_config.yml');
     const webhintThemeDir = path.join(hexoDir, theme, '_config.yml');
-    const menuData = yaml.safeLoad(fs.readFileSync(menuDataDir, 'utf8')); // eslint-disable-line no-sync
-    const config = yaml.safeLoad(fs.readFileSync(configDataDir, 'utf8')); // eslint-disable-line no-sync
-    const webhintTheme = yaml.safeLoad(fs.readFileSync(webhintThemeDir, 'utf8')); // eslint-disable-line no-sync
+    const menuData = yaml.load(fs.readFileSync(menuDataDir, 'utf8')); // eslint-disable-line no-sync
+    const config = yaml.load(fs.readFileSync(configDataDir, 'utf8')); // eslint-disable-line no-sync
+    const webhintTheme = yaml.load(fs.readFileSync(webhintThemeDir, 'utf8')); // eslint-disable-line no-sync
 
     app.set('hexoDir', hexoDir);
     app.set('rootPath', rootPath);


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/webhintio/webhint.io)
- [x] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

## Short description of the change(s)
When running `npm start` node throws and error

Error: Function yaml.safeLoad is removed in js-yaml 4. Use yaml.load instead, which is now safe by default.

This fixes this issue
<!--

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
